### PR TITLE
Fix of "Use of uninitialized value $t in substitution"

### DIFF
--- a/bin/cfgmaker
+++ b/bin/cfgmaker
@@ -1370,6 +1370,7 @@ sub addrouter() {
             for my $g (@{$$opt{"global"}}) {
                 my ($t,$fs);
                 $g =~ /^options\[([_^\$])\]:\s*(.*)$/i;
+		next unless (defined $1 && defined $2);
                 $t = $1;
                 $fs = $2;
                 $t =~ s/_/default/;


### PR DESCRIPTION
Following command issues multiple errors:
```
/usr/bin/cfgmaker --global "forks: 2" --global "HtmlDir: /var/www/mrtg" --global "ImageDir: /var/www/mrtg"     --global "LogDir: /var/lib/mrtg" --global "ThreshDir: /var/lib/mrtg" --global "Options[_]: growright,bits"     --global "LogFormat: rrdtool" --global "IconDir: /mrtg" --subdirs=HOSTNAME     --if-filter='$default && ($if_type != 53)' --ifref=name --ifdesc=alias public@sw-4
Use of uninitialized value $t in substitution (s///) at /usr/bin/cfgmaker line 1376.
Use of uninitialized value $t in substitution (s///) at /usr/bin/cfgmaker line 1377.
Use of uninitialized value $t in substitution (s///) at /usr/bin/cfgmaker line 1378.
Use of uninitialized value $fs in pattern match (m//) at /usr/bin/cfgmaker line 1383.
Use of uninitialized value $t in hash element at /usr/bin/cfgmaker line 1384.
...
```